### PR TITLE
Multiple responses to relationship questions

### DIFF
--- a/src/QuestionParser.js
+++ b/src/QuestionParser.js
@@ -282,6 +282,7 @@ class QuestionParser {
     const data = t.match(/^(\bwho\b|\bwhat\b) ([a-zA-Z0-9_ ]*)/i);
     const body = data[2].replace(/\ban\b/gi, '').replace(/\bthe\b/gi, '').replace(/\ba\b/gi, '');
     const tokens = body.split(' ');
+    const uniqueResponses = new Set([]);
     let instance;
     for (let i = 0; i < tokens.length; i += 1) {
       const testString = tokens.slice(tokens.length - (i + 1), tokens.length).join(' ').trim();
@@ -295,6 +296,7 @@ class QuestionParser {
         break;
       }
     }
+
     if (instance) {
       const propertyName = tokens.splice(0, tokens.length - instance.name.split(' ').length).join(' ').trim();
       for (let i = 0; i < this.node.instances.length; i += 1) {
@@ -316,7 +318,11 @@ class QuestionParser {
           property = subject.property(fixedPropertyName);
         }
         if (property && property.name === instance.name) {
-          return QuestionParser.success(`${subject.name} ${fixedPropertyName} the ${property.type.name} ${property.name}.`);
+          uniqueResponses.add(`${subject.name} ${fixedPropertyName} the ${property.type.name} ${property.name}.`);
+        }
+        const responsesArray = Array.from(uniqueResponses);
+        if (responsesArray.length > 0 && i === this.node.instances.length - 1) {
+          return QuestionParser.success(responsesArray.join(' '));
         }
       }
       return QuestionParser.success(`Sorry - I don't know that property about the ${instance.type.name} ${instance.name}.`);

--- a/test/QuestionParser.js
+++ b/test/QuestionParser.js
@@ -1,0 +1,40 @@
+const CENode = require('../src/CENode.js');
+const CEModels = require('../models/index.js');
+const expect = require('expect.js');
+const myName = 'User'
+const PLANETS_MODEL = [
+  "there is a rule named 'r1' that has 'if the planet C ~ orbits ~ the star D then the star D ~ is orbited by ~ the planet C' as instruction.",
+  "there is a rule named 'r2' that has 'if the planet C ~ is orbited by ~ the moon D then the moon D ~ orbits ~ the planet C' as instruction.",
+  "conceptualise a ~ celestial body ~ C.",
+  "conceptualise the celestial body C ~ orbits ~ the celestial body D and ~ is orbited by ~ the celestial body E.",
+  "conceptualise a ~ planet ~ P that is a celestial body and is an imageable thing.",
+  "conceptualise a ~ star ~ S that is a celestial body.",
+  "there is a star named sun.",
+  "there is a planet named Venus that orbits the star 'sun' and has 'media/Venus.jpg' as image.",
+  "there is a planet named Mercury that orbits the star 'sun' and has 'media/Mercury.jpg' as image."
+]
+
+let node;
+describe('CEQuestionParser', function() {
+  describe('What relation questions', function () {
+    this.timeout(2050);
+    before(function() {
+      node = new CENode(CEModels.core, PLANETS_MODEL);
+      node.attachAgent();
+      node.agent.setName('agent1');
+    });
+    it('returns the correct number of responses', (done) => {
+      const message = 'what orbits the sun?';
+      const askCard = "there is a nl card named '{uid}' that is to the agent 'agent1' and is from the individual '" + myName + "' and has the timestamp '{now}' as timestamp and has '" + message.replace(/'/g, "\\'")+"' as content.";
+      
+      node.addSentence(askCard);
+      
+      setTimeout(function() {
+        const cards = node.concepts.card.allInstances;
+        const card = cards[cards.length - 1];
+        expect(card.content).to.equal('Venus orbits the star sun. Mercury orbits the star sun.');
+        done();
+      }, 2000);
+    });
+  });
+});


### PR DESCRIPTION
Firstly, thank you to all those involved in the developing CENode! It is a very cool library and a perfect fit for the project I am working on.

While following the [Getting Started Guide](https://github.com/flyingsparx/CENode/wiki/Getting-Started-Guide), I noticed that when asking a relationship question like 
"What orbits the sun?", only a single answer would be returned. Here is a screen shot from the demo.
<img width="393" alt="screen shot 2018-03-18 at 12 52 58 am" src="https://user-images.githubusercontent.com/4009178/37562772-bc3e9470-2a46-11e8-8fb2-b1e589a45af0.png">

After looking over the implementation of the `QuestionParser` class, it seemed that once a valid response is found in the `whatRelationship` function, it short circuits only returning the first match.

This PR introduces a small change to the logic that allows for multiple unique responses to be returned for "what relationship" questions. The new expected behavior would be as follows.

For a question like "What orbits the sun?" the response would be "Mercury orbits the star sun. Venus orbits the star sun. Earth orbits... etc"

If this proposed code change diverges from the CEStore specification, I can withdraw this PR. It just seemed that if multiple instances in the knowledge base matched a query, they should be included in the response.

I wasn't sure how to best test this behavior. My naive attempt consisted of replicating the broken behavior exhibited in the demo. In order to wait for the gist card to be present, I needed to use a `setTimeout` similarly to how it is used in the demo code. I found this lead to false positives if I wasn't being careful, so if there is a better way to unit test for this behavior, I can definitely rework the test.



